### PR TITLE
Add prepublish script

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -10,6 +10,7 @@
     "check": "npm run audit && npm outdated --depth 0",
     "coverage": "jest --coverage",
     "lint": "eslint src test",
+    "prepublish": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "validate": "npm run lint && npm test",


### PR DESCRIPTION
Add `"prepublish": "npm run build"` to generated **package.json** to ensure a build occurs prior to publishing.