### PR TITLE
Remove whatwg-fetch

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -29,8 +29,7 @@
     "jest": "^18.1.0",
     "nsp": "^2.6.1",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^1.16.3",
-    "whatwg-fetch": "^2.0.2"
+    "webpack-dev-server": "^1.16.3"
   },
   "author": "Ritter Insurance Marketing",
   "license": "UNLICENSED"

--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -24,7 +24,6 @@ if (process.env.INCLUDE_WEBPACK_HTML) {
 module.exports = {
   entry: [
     'babel-polyfill',
-    'whatwg-fetch',
     './src/<%= filename %>.js'
   ],
   output: {


### PR DESCRIPTION
Not all components may need a fetch polyfill. Let's leave it out and expect generator users to implement **whatwg-fetch** as necessary.