### PR TITLE
Remove generated .editorconfig end_of_line property

### DIFF
--- a/generators/app/templates/.editorconfig
+++ b/generators/app/templates/.editorconfig
@@ -2,7 +2,6 @@ root = false
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true


### PR DESCRIPTION
Let's remove the line ending specification from the generated **.editorconfig**.