### PR TITLE
Fix tests by running and asserting correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+ # 1.2.5
+ - Fix mocha to run the generator/assert correctly
+ 
  # 1.2.4
  - Add Mocha for testing the generator
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ritterim/generator-rim-es6-component"
   },
   "license": "MIT",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Creates an es6 component based on the RimDev component template",
   "files": [
     "generators"
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0",
+    "yeoman-assert": "^3.0.0",
     "yeoman-test": "^1.6.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
 
 describe('Rim ES6 component generator', function() {
   beforeEach(function(done) {
@@ -13,49 +14,41 @@ describe('Rim ES6 component generator', function() {
         this.app = helpers.createGenerator('rim-es6-component', [
           '../../generators/app'
         ]);
-        done();
+        helpers.mockPrompt(this.app, {
+          name: 'test-app',
+          withFetch: 'No'
+        });
+        this.app.options['skip-install'] = true;
+        this.app.run(done);
       }).bind(this)
     );
   });
 
-  it('creates expected config files', function() {
+  it('creates expected config files', function () {
     var expected = [
-      '.editorconfig',
-      '.gitignore',
-      '.eslintrc',
-      '.babelrc',
-      'package.json',
-      'build.cmd',
-      'README.md',
-      'webpack.config.js'
+      'test-app/.editorconfig',
+      'test-app/.gitignore',
+      'test-app/.eslintrc',
+      'test-app/.babelrc',
+      'test-app/package.json',
+      'test-app/build.cmd',
+      'test-app/README.md',
+      'test-app/webpack.config.js'
     ];
 
-    helpers.mockPrompt(this.app, {
-      name: 'test-app',
-      withFetch: 'No'
-    });
-    this.app.options['skip-install'] = true;
-    this.app.run({}, function() {
-      helpers.assertFile(expected);
-      done();
-    });
+    assert.file(expected);
+
   });
 
   it('creates expected source files', function() {
     var expected = [
-      'src/test-app.js',
-      'test/test-app.test.js'
+      'test-app/src/test-app.js',
+      'test-app/test/test-app.test.js'
     ];
 
-    helpers.mockPrompt(this.app, {
-      name: 'test-app',
-      withFetch: 'No'
-    });
-    this.app.options['skip-install'] = true;
-    this.app.run({}, function() {
-      helpers.assertFile(expected);
-      done();
-    });
+
+    assert.file(expected);
+
   });
 
 });


### PR DESCRIPTION
Okay this works. You can add `throw new Error()` and the test will fail, and adding a file that doesn't exist also fails the tests.